### PR TITLE
Make proxying optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -259,6 +259,27 @@ This has the effect of four slashes being present for an absolute
 file path: sqlite:////full/path/to/your/database/file.sqlite.
 
 
+Interpolate environment variables
+---------------------------------
+
+Values that being with a ``$`` will be interpolated. Pass ``interpolate=False`` to ``environ.Env()`` to disable this feature.
+
+.. code-block:: bash
+
+    PROXIED_VAR=$STR_VAR
+    STR_VAR=bar
+
+.. code-block:: python
+
+    env = environ.Env()
+    env.str('PROXIED_VAR')
+    >>> 'bar'
+
+    env = environ.Env(interpolate=False)
+    env.str('PROXIED_VAR')
+    >>> '$STR_VAR'
+
+
 Tests
 =====
 

--- a/environ/environ.py
+++ b/environ/environ.py
@@ -123,7 +123,8 @@ class Env(object):
         "simple": "haystack.backends.simple_backend.SimpleEngine",
     }
 
-    def __init__(self, **scheme):
+    def __init__(self, interpolate=True, **scheme):
+        self.interpolate = interpolate
         self.scheme = scheme
 
     def __call__(self, var, cast=None, default=NOTSET, parse_default=False):
@@ -277,7 +278,7 @@ class Env(object):
             value = default
 
         # Resolve any proxied values
-        if hasattr(value, 'startswith') and value.startswith('$'):
+        if self.interpolate and hasattr(value, 'startswith') and value.startswith('$'):
             value = value.lstrip('$')
             value = self.get_value(value, cast=cast, default=default)
 

--- a/environ/test.py
+++ b/environ/test.py
@@ -116,6 +116,10 @@ class EnvTests(BaseTests):
     def test_proxied_value(self):
         self.assertTypeAndValue(str, 'bar', self.env('PROXIED_VAR'))
 
+    def test_proxied_value_interpolate_false(self):
+        env = Env(interpolate=False)
+        self.assertTypeAndValue(str, '$STR_VAR', env('PROXIED_VAR'))
+
     def test_int_list(self):
         self.assertTypeAndValue(list, [42, 33], self.env('INT_LIST', cast=[int]))
         self.assertTypeAndValue(list, [42, 33], self.env.list('INT_LIST', int))


### PR DESCRIPTION
Pass `interpolate=False` to `environ.Env`

eg.

```
PROXIED_VAR=$STR_VAR
STR_VAR=bar
```

```
env = environ.Env()
env.str('PROXIED_VAR')
>>> 'bar'

env = environ.Env(interpolate=False)
env.str('PROXIED_VAR')
>>> '$STR_VAR'
```